### PR TITLE
Output latest version of go Git Helper

### DIFF
--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -23,7 +23,7 @@ var (
 	newPath    = "/usr/local/bin/go-git-helper" // TODO: switch this to git-helper, it's leftover from the migration
 )
 
-func NewCommand(currentVersion string) *cobra.Command {
+func NewCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "update",
 		Short:                 "Updates Git Helper with the newest version on GitHub",
@@ -31,7 +31,7 @@ func NewCommand(currentVersion string) *cobra.Command {
 		DisableFlagParsing:    true,
 		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			newUpdate().execute(currentVersion)
+			newUpdate().execute()
 			return nil
 		},
 	}
@@ -43,14 +43,15 @@ func newUpdate() *Update {
 	return &Update{}
 }
 
-func (u *Update) execute(currentVersion string) {
-	downloadGitHelper(currentVersion)
+func (u *Update) execute() {
+	downloadGitHelper()
 	moveGitHelper()
 	setPermissions()
+	outputNewVersion()
 }
 
-func downloadGitHelper(currentVersion string) {
-	fmt.Printf("Installing git-helper version %s\n", currentVersion)
+func downloadGitHelper() {
+	fmt.Println("Installing latest git-helper version")
 
 	releaseURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/latest", owner, repository)
 	resp, err := http.Get(releaseURL)
@@ -126,4 +127,14 @@ func setPermissions() {
 	}
 
 	fmt.Printf("%s", string(output))
+}
+
+func outputNewVersion() {
+	cmd := exec.Command("go-git-helper", "version") // TODO: make this command git-helper
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
+	fmt.Printf("Installed %s", string(output))
 }

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	packageVersion = "beta-0.0.3"
+	packageVersion = "beta-0.0.4"
 )
 
 func main() {
@@ -50,7 +50,7 @@ func newCommand() *cobra.Command {
 	cmd.AddCommand(forgetLocalCommits.NewCommand())
 	cmd.AddCommand(newBranch.NewCommand())
 	cmd.AddCommand(setup.NewCommand())
-	cmd.AddCommand(update.NewCommand(packageVersion))
+	cmd.AddCommand(update.NewCommand())
 	cmd.AddCommand(version.NewCommand(packageVersion))
 
 	return cmd


### PR DESCRIPTION
## Changes

> A list of the changes that your pull request will make:
>
> * Adding a page "..."
> * Refactoring "..."

After updating Git Helper, output the current version by running the command, not by outputting what was passed in.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue URL link
> * Pull Request URL link

## Additional Context

> Add any other context about the problem here.
