### PR TITLE
Preserve color of output during git commands

### DIFF
--- a/cmd/newBranch/newBranch.go
+++ b/cmd/newBranch/newBranch.go
@@ -65,6 +65,7 @@ func getValidBranch() string {
 }
 
 func (nb *NewBranch) execute() {
+	fmt.Println("Attempting to create a new branch:", nb.branch)
 	git.Pull()
 	git.CreateBranch(nb.branch)
 	git.Checkout(nb.branch)

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -152,6 +152,12 @@ func createOrUpdatePlugins() {
 			log.Fatal(err)
 			continue
 		}
+
+		err = os.Chmod(pluginPath, 0755)
+		if err != nil {
+			fmt.Println("Error:", err)
+			return
+		}
 	}
 
 	fmt.Printf("\nDone setting up plugins at %s!\n", pluginsDir)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -260,7 +260,7 @@ func StashDrop() {
 
 	err = cmd.Wait()
 	if err != nil {
-		log.Fatal(err)
+		// The command output an error itself, so we can just be done
 		return
 	}
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -3,6 +3,7 @@ package git
 import (
 	"fmt"
 	"log"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -10,13 +11,20 @@ import (
 
 func Checkout(branch string) {
 	cmd := exec.Command("git", "checkout", branch)
-	output, err := cmd.CombinedOutput()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Start()
 	if err != nil {
 		log.Fatal(err)
 		return
 	}
 
-	fmt.Printf("%s", string(output))
+	err = cmd.Wait()
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
 }
 
 func CleanDeletedBranches() {
@@ -49,24 +57,38 @@ func CleanDeletedBranches() {
 
 func CreateBranch(branch string) {
 	cmd := exec.Command("git", "branch", "--no-track", branch)
-	output, err := cmd.CombinedOutput()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Start()
 	if err != nil {
 		log.Fatal(err)
 		return
 	}
 
-	fmt.Printf("%s", string(output))
+	err = cmd.Wait()
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
 }
 
 func CreateEmptyCommit() {
 	cmd := exec.Command("git", "commit", "--allow-empty", "-m", "Empty commit")
-	output, err := cmd.CombinedOutput()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Start()
 	if err != nil {
 		log.Fatal(err)
 		return
 	}
 
-	fmt.Printf("%s", string(output))
+	err = cmd.Wait()
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
 }
 
 func CurrentBranch() string {
@@ -106,35 +128,56 @@ func DefaultBranch() string {
 
 func Fetch() {
 	cmd := exec.Command("git", "fetch", "-p")
-	output, err := cmd.CombinedOutput()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Start()
 	if err != nil {
 		log.Fatal(err)
 		return
 	}
 
-	fmt.Printf("%s", string(output))
+	err = cmd.Wait()
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
 }
 
 func Pull() {
 	cmd := exec.Command("git", "pull")
-	output, err := cmd.CombinedOutput()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Start()
 	if err != nil {
 		log.Fatal(err)
 		return
 	}
 
-	fmt.Printf("%s", string(output))
+	err = cmd.Wait()
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
 }
 
 func PushBranch(branch string) {
 	cmd := exec.Command("git", "push", "--set-upstream", "origin", branch)
-	output, err := cmd.CombinedOutput()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Start()
 	if err != nil {
 		log.Fatal(err)
 		return
 	}
 
-	fmt.Printf("%s", string(output))
+	err = cmd.Wait()
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
 }
 
 func RepoName() string {
@@ -170,33 +213,54 @@ func Remotes() []string {
 
 func Reset() {
 	cmd := exec.Command("git", "reset", "--hard", "origin/HEAD")
-	output, err := cmd.CombinedOutput()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Start()
 	if err != nil {
 		log.Fatal(err)
 		return
 	}
 
-	fmt.Printf("%s", string(output))
+	err = cmd.Wait()
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
 }
 
 func Stash() {
 	cmd := exec.Command("git", "stash")
-	output, err := cmd.CombinedOutput()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Start()
 	if err != nil {
 		log.Fatal(err)
 		return
 	}
 
-	fmt.Printf("%s", string(output))
+	err = cmd.Wait()
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
 }
 
 func StashDrop() {
 	cmd := exec.Command("git", "stash", "drop")
-	output, err := cmd.CombinedOutput()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Start()
 	if err != nil {
 		log.Fatal(err)
 		return
 	}
 
-	fmt.Printf("%s", string(output))
+	err = cmd.Wait()
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
 }

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	packageVersion = "beta-0.0.4"
+	packageVersion = "beta-0.0.5"
 )
 
 func main() {


### PR DESCRIPTION
## Changes

> A list of the changes that your pull request will make:
>
> * Adding a page "..."
> * Refactoring "..."

* Preserve color in git commands
* Don't say I'm erroring when stash dropping... just let it do its thing
* Have the update command properly set the permissions on each plugin file to be executable
* Have the new branch command properly say what branch name it's attempting to create
* Update beta version tag

During the output of git commands, color should be preserved where there was original color.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue URL link
> * Pull Request URL link

## Additional Context

> Add any other context about the problem here.
