### PR TITLE
Add command to set head ref; print debug stacktrace on erroring

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,13 +141,6 @@ This command will check out the default branch of whatever repository you're cur
 git-helper checkout-default
 ```
 
-If your local branches aren't formatted correctly (run `git branch --remote` to see), then run (assuming default branch is `main`):
-
-```bash
-git branch --set-upstream-to=origin/main main
-git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
-```
-
 ### `clean-branches`
 
 This command will bring you to the repository's default branch, `git pull`, `git fetch -p`, and will clean up your local branches on your machine by seeing which ones are existing on the remote, and updating yours accordingly. To clean your local branches, run:

--- a/README.md
+++ b/README.md
@@ -203,6 +203,30 @@ git-helper new-branch [optionalBranch]
 
 The command either accepts a branch name right away or it will ask you for the name of your new branch. Make sure your input does not contain any spaces or special characters.
 
+### `set-head-ref`
+
+Sets the upstream and `HEAD` symbolic ref to the default branch passed in:
+
+```bash
+git-helper set-head-ref [defaultBranch]
+```
+
+### `setup`
+
+See [`Setup`](#setup).
+
+### `update`
+
+See [`Updating Git Helper`](#updating-git-helper).
+
+### `version`
+
+Show's the local version of Git Helper installed:
+
+```bash
+git-helper version
+```
+
 ## Migrating from the Ruby version of Git Helper
 
 1. Uninstall Ruby's Git Helper:
@@ -217,7 +241,7 @@ The command either accepts a branch name right away or it will ask you for the n
     # Verify it's gone by this command returning command not found
     git-helper -v
     ```
-2. Install Go's Git Helper by following the instructions in the beginning of this `README`
+2. Install Go's Git Helper by following the instructions in [`Installation`](#installation)
 3. Check Go's Git Helper is installed:
     ```bash
     git-helper version

--- a/cmd/changeRemote/changeRemote.go
+++ b/cmd/changeRemote/changeRemote.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 
 	"github.com/emmahsax/go-git-helper/internal/commandline"
@@ -73,7 +74,8 @@ func processGitRepository(cr *ChangeRemote) {
 	cmd := exec.Command("git", "remote", "-v")
 	output, err := cmd.Output()
 	if err != nil {
-		log.Fatal("Error:", err)
+		debug.PrintStack()
+		log.Fatal(err)
 		return
 	}
 
@@ -110,7 +112,8 @@ func processRemote(remote, host, repo, remoteName string, cr *ChangeRemote) {
 	cmd := exec.Command("git", "remote", "set-url", remoteName, newRemote)
 	_, err := cmd.Output()
 	if err != nil {
-		log.Fatal("Error:", err)
+		debug.PrintStack()
+		log.Fatal(err)
 		return
 	}
 }

--- a/cmd/setHeadRef/setHeadRef.go
+++ b/cmd/setHeadRef/setHeadRef.go
@@ -5,7 +5,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type SetHeadRef struct{
+type SetHeadRef struct {
 	defaultBranch string
 }
 

--- a/cmd/setHeadRef/setHeadRef.go
+++ b/cmd/setHeadRef/setHeadRef.go
@@ -1,0 +1,36 @@
+package setHeadRef
+
+import (
+	"github.com/emmahsax/go-git-helper/internal/git"
+	"github.com/spf13/cobra"
+)
+
+type SetHeadRef struct{
+	defaultBranch string
+}
+
+func NewCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "set-head-ref [defaultBranch]",
+		Short:                 "Sets the HEAD ref as a symbolic ref",
+		Args:                  cobra.ExactArgs(1),
+		DisableFlagParsing:    true,
+		DisableFlagsInUseLine: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			setHeadRef(args[0]).execute()
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func setHeadRef(defaultBranch string) *SetHeadRef {
+	return &SetHeadRef{
+		defaultBranch: defaultBranch,
+	}
+}
+
+func (shr *SetHeadRef) execute() {
+	git.SetHeadRef(shr.defaultBranch)
+}

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 
 	"github.com/emmahsax/go-git-helper/internal/commandline"
@@ -62,6 +63,7 @@ func createOrUpdateConfig() {
 	if !configfile.ConfigDirExists() {
 		err := os.Mkdir(configfile.ConfigDir(), 0755)
 		if err != nil {
+			debug.PrintStack()
 			log.Fatal(err)
 			return
 		}
@@ -69,6 +71,7 @@ func createOrUpdateConfig() {
 
 	err := os.WriteFile(configfile.ConfigFile(), []byte(content), 0644)
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
@@ -111,12 +114,14 @@ func createOrUpdatePlugins() {
 	pluginsURL := "https://api.github.com/repos/emmahsax/go-git-helper/contents/plugins"
 
 	if err := os.MkdirAll(pluginsDir, 0755); err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
 
 	resp, err := http.Get(pluginsURL)
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal("Error:", err)
 		return
 	}
@@ -124,6 +129,7 @@ func createOrUpdatePlugins() {
 
 	var allPlugins []map[string]interface{}
 	if err := json.NewDecoder(resp.Body).Decode(&allPlugins); err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
@@ -134,6 +140,7 @@ func createOrUpdatePlugins() {
 
 		resp, err := http.Get(pluginURL)
 		if err != nil {
+			debug.PrintStack()
 			log.Fatal(err)
 			continue
 		}
@@ -142,6 +149,7 @@ func createOrUpdatePlugins() {
 		pluginPath := filepath.Join(pluginsDir, pluginName)
 		file, err := os.Create(pluginPath)
 		if err != nil {
+			debug.PrintStack()
 			log.Fatal(err)
 			continue
 		}
@@ -149,6 +157,7 @@ func createOrUpdatePlugins() {
 
 		_, err = io.Copy(file, resp.Body)
 		if err != nil {
+			debug.PrintStack()
 			log.Fatal(err)
 			continue
 		}

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -21,7 +21,7 @@ var (
 	asset      = "git-helper_darwin_arm64"
 	owner      = "emmahsax"
 	repository = "go-git-helper"
-	newPath    = "/usr/local/bin/go-git-helper" // TODO: switch this to git-helper, it's leftover from the migration
+	newPath    = "/usr/local/bin/git-helper"
 )
 
 func NewCommand() *cobra.Command {
@@ -139,7 +139,7 @@ func setPermissions() {
 }
 
 func outputNewVersion() {
-	cmd := exec.Command("go-git-helper", "version") // TODO: make this command git-helper
+	cmd := exec.Command("git-helper", "version")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		debug.PrintStack()

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"runtime/debug"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -56,6 +57,7 @@ func downloadGitHelper() {
 	releaseURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/latest", owner, repository)
 	resp, err := http.Get(releaseURL)
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
@@ -63,6 +65,7 @@ func downloadGitHelper() {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
@@ -79,6 +82,7 @@ func downloadGitHelper() {
 	binaryName := strings.Split(downloadURL, "/")[len(strings.Split(downloadURL, "/"))-1]
 	resp, err = http.Get(downloadURL)
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
@@ -86,6 +90,7 @@ func downloadGitHelper() {
 
 	out, err := os.Create(binaryName)
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
@@ -93,6 +98,7 @@ func downloadGitHelper() {
 
 	_, err = io.Copy(out, resp.Body)
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
@@ -102,6 +108,7 @@ func moveGitHelper() {
 	cmd := exec.Command("sudo", "mv", "./"+asset, newPath)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
@@ -113,6 +120,7 @@ func setPermissions() {
 	cmdChown := exec.Command("sudo", "chown", "root:wheel", newPath)
 	output, err := cmdChown.CombinedOutput()
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
@@ -122,6 +130,7 @@ func setPermissions() {
 	cmdChmod := exec.Command("sudo", "chmod", "+x", newPath)
 	output, err = cmdChmod.CombinedOutput()
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
@@ -133,6 +142,7 @@ func outputNewVersion() {
 	cmd := exec.Command("go-git-helper", "version") // TODO: make this command git-helper
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}

--- a/internal/configfile/configfile.go
+++ b/internal/configfile/configfile.go
@@ -3,14 +3,16 @@ package configfile
 import (
 	"log"
 	"os"
+	"runtime/debug"
 
-	"gopkg.in/yaml.v3"
+	yaml "gopkg.in/yaml.v3"
 )
 
 func ConfigDir() string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		log.Fatal("Error:", err)
+		debug.PrintStack()
+		log.Fatal(err)
 		return ""
 	}
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -254,7 +254,7 @@ func Reset() {
 }
 
 func SetHeadRef(defaultBranch string) {
-	cmd := exec.Command("git", "branch", "--set-upstream-to=origin/" + defaultBranch, defaultBranch)
+	cmd := exec.Command("git", "branch", "--set-upstream-to=origin/"+defaultBranch, defaultBranch)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
@@ -272,7 +272,7 @@ func SetHeadRef(defaultBranch string) {
 		return
 	}
 
-	cmd = exec.Command("git", "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/" + defaultBranch)
+	cmd = exec.Command("git", "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/"+defaultBranch)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -124,8 +124,7 @@ func DefaultBranch() string {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if string(output) == "fatal: ref refs/remotes/origin/HEAD is not a symbolic ref\n" {
-			// TODO: switch this to git-helper, it's leftover from the migration
-			fmt.Printf("\nYour symbolic ref is not set up properly. Please run:\n  go-git-helper set-head-ref [defaultBranch]\n\nAnd then try your command again.\n\n")
+			fmt.Printf("\nYour symbolic ref is not set up properly. Please run:\n  git-helper set-head-ref [defaultBranch]\n\nAnd then try your command again.\n\n")
 		}
 		debug.PrintStack()
 		log.Fatal(err)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"runtime/debug"
 	"strings"
 )
 
@@ -16,12 +17,14 @@ func Checkout(branch string) {
 
 	err := cmd.Start()
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
 
 	err = cmd.Wait()
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
@@ -31,6 +34,7 @@ func CleanDeletedBranches() {
 	cmd := exec.Command("git", "branch", "-vv")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
@@ -46,6 +50,7 @@ func CleanDeletedBranches() {
 			cmd = exec.Command("git", "branch", "-D", b)
 			output, err := cmd.CombinedOutput()
 			if err != nil {
+				debug.PrintStack()
 				log.Fatal(err)
 				return
 			}
@@ -62,12 +67,14 @@ func CreateBranch(branch string) {
 
 	err := cmd.Start()
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
 
 	err = cmd.Wait()
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
@@ -80,12 +87,14 @@ func CreateEmptyCommit() {
 
 	err := cmd.Start()
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
 
 	err = cmd.Wait()
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
@@ -95,6 +104,7 @@ func CurrentBranch() string {
 	cmd := exec.Command("git", "branch")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return ""
 	}
@@ -113,6 +123,11 @@ func DefaultBranch() string {
 	cmd := exec.Command("git", "symbolic-ref", "refs/remotes/origin/HEAD")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		if string(output) == "fatal: ref refs/remotes/origin/HEAD is not a symbolic ref\n" {
+			// TODO: switch this to git-helper, it's leftover from the migration
+			fmt.Printf("\nYour symbolic ref is not set up properly. Please run:\n  go-git-helper set-head-ref [defaultBranch]\n\nAnd then try your command again.\n\n")
+		}
+		debug.PrintStack()
 		log.Fatal(err)
 		return ""
 	}
@@ -133,12 +148,14 @@ func Fetch() {
 
 	err := cmd.Start()
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
 
 	err = cmd.Wait()
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
@@ -151,12 +168,14 @@ func Pull() {
 
 	err := cmd.Start()
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
 
 	err = cmd.Wait()
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
@@ -169,12 +188,14 @@ func PushBranch(branch string) {
 
 	err := cmd.Start()
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
 
 	err = cmd.Wait()
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
@@ -193,6 +214,7 @@ func RepoName() string {
 	if len(match) >= 2 {
 		return match[1]
 	} else {
+		debug.PrintStack()
 		log.Fatal("No match found")
 	}
 
@@ -204,6 +226,7 @@ func Remotes() []string {
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return []string{}
 	}
@@ -218,12 +241,52 @@ func Reset() {
 
 	err := cmd.Start()
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
 
 	err = cmd.Wait()
 	if err != nil {
+		debug.PrintStack()
+		log.Fatal(err)
+		return
+	}
+}
+
+func SetHeadRef(defaultBranch string) {
+	cmd := exec.Command("git", "branch", "--set-upstream-to=origin/" + defaultBranch, defaultBranch)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err := cmd.Start()
+	if err != nil {
+		debug.PrintStack()
+		log.Fatal(err)
+		return
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		debug.PrintStack()
+		log.Fatal(err)
+		return
+	}
+
+	cmd = exec.Command("git", "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/" + defaultBranch)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err = cmd.Start()
+	if err != nil {
+		debug.PrintStack()
+		log.Fatal(err)
+		return
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
@@ -236,12 +299,14 @@ func Stash() {
 
 	err := cmd.Start()
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
 
 	err = cmd.Wait()
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}
@@ -254,6 +319,7 @@ func StashDrop() {
 
 	err := cmd.Start()
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return
 	}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"runtime/debug"
 
 	"github.com/emmahsax/go-git-helper/internal/configfile"
 )
@@ -34,11 +35,13 @@ func (c *GitHubClient) run(username, requestType, curlURL string, payload map[st
 	var result Response
 	jsonBytes, err := json.Marshal(payload)
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return result
 	}
 	req, err := http.NewRequest(requestType, "https://api.github.com"+curlURL, bytes.NewBuffer(jsonBytes))
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return result
 	}
@@ -49,6 +52,7 @@ func (c *GitHubClient) run(username, requestType, curlURL string, payload map[st
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return result
 	}
@@ -56,6 +60,7 @@ func (c *GitHubClient) run(username, requestType, curlURL string, payload map[st
 
 	body, _ := io.ReadAll(resp.Body)
 	if err := json.Unmarshal(body, &result); err != nil {
+		debug.PrintStack()
 		log.Fatal("Cannot unmarshal JSON")
 		return err
 	}

--- a/internal/githubPullRequest/githubPullRequest.go
+++ b/internal/githubPullRequest/githubPullRequest.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 
 	"github.com/emmahsax/go-git-helper/internal/commandline"
 	"github.com/emmahsax/go-git-helper/internal/github"
@@ -40,6 +41,7 @@ func (pr *GitHubPullRequest) Create() {
 
 	if prResponse.HtmlURL == "" {
 		errorMessage := prResponse.Errors[0].Message
+		debug.PrintStack()
 		log.Fatal("Could not create pull request: " + errorMessage)
 	} else {
 		fmt.Println("Pull request successfully created:", prResponse.HtmlURL)
@@ -51,6 +53,7 @@ func newPrBody() string {
 	if templateName != "" {
 		content, err := os.ReadFile(templateName)
 		if err != nil {
+			debug.PrintStack()
 			log.Fatal(err)
 		}
 

--- a/internal/gitlab/gitlab.go
+++ b/internal/gitlab/gitlab.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"runtime/debug"
 	"strings"
 
 	"github.com/emmahsax/go-git-helper/internal/configfile"
@@ -31,6 +32,7 @@ func (c *GitLabClient) run(requestType, curlURL string) interface{} {
 	var result Response
 	req, err := http.NewRequest(requestType, fmt.Sprintf("https://gitlab.com/api/v4%s", curlURL), nil)
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return result
 	}
@@ -40,6 +42,7 @@ func (c *GitLabClient) run(requestType, curlURL string) interface{} {
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
+		debug.PrintStack()
 		log.Fatal(err)
 		return result
 	}
@@ -47,6 +50,7 @@ func (c *GitLabClient) run(requestType, curlURL string) interface{} {
 
 	body, _ := io.ReadAll(resp.Body)
 	if err := json.Unmarshal(body, &result); err != nil {
+		debug.PrintStack()
 		log.Fatal("Cannot unmarshal JSON")
 		return err
 	}

--- a/internal/gitlabMergeRequest/gitlabMergeRequest.go
+++ b/internal/gitlabMergeRequest/gitlabMergeRequest.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 
 	"github.com/emmahsax/go-git-helper/internal/commandline"
 	"github.com/emmahsax/go-git-helper/internal/gitlab"
@@ -42,6 +43,7 @@ func (mr *GitLabMergeRequest) Create() {
 
 	if mrResponse.WebURL == "" {
 		errorMessage := mrResponse.Message[0]
+		debug.PrintStack()
 		log.Fatal("Could not create merge request: " + errorMessage)
 	} else {
 		fmt.Println("Merge request successfully created:", mrResponse.WebURL)
@@ -53,6 +55,7 @@ func newMrBody() string {
 	if templateName != "" {
 		content, err := os.ReadFile(templateName)
 		if err != nil {
+			debug.PrintStack()
 			log.Fatal(err)
 		}
 

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/emmahsax/go-git-helper/cmd/forgetLocalChanges"
 	"github.com/emmahsax/go-git-helper/cmd/forgetLocalCommits"
 	"github.com/emmahsax/go-git-helper/cmd/newBranch"
+	"github.com/emmahsax/go-git-helper/cmd/setHeadRef"
 	"github.com/emmahsax/go-git-helper/cmd/setup"
 	"github.com/emmahsax/go-git-helper/cmd/update"
 	"github.com/emmahsax/go-git-helper/cmd/version"
@@ -50,6 +51,7 @@ func newCommand() *cobra.Command {
 	cmd.AddCommand(forgetLocalCommits.NewCommand())
 	cmd.AddCommand(newBranch.NewCommand())
 	cmd.AddCommand(setup.NewCommand())
+	cmd.AddCommand(setHeadRef.NewCommand())
 	cmd.AddCommand(update.NewCommand())
 	cmd.AddCommand(version.NewCommand(packageVersion))
 

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	packageVersion = "beta-0.0.5"
+	packageVersion = "beta-0.0.6"
 )
 
 func main() {

--- a/plugins/git-change-remote
+++ b/plugins/git-change-remote
@@ -1,5 +1,3 @@
 #!/bin/sh
 
-# TODO: switch this to plain git-helper, as that's leftover from ruby to go migration
-
-go-git-helper change-remote $1 $2
+git-helper change-remote $1 $2

--- a/plugins/git-checkout-default
+++ b/plugins/git-checkout-default
@@ -1,5 +1,3 @@
 #!/bin/sh
 
-# TODO: switch this to plain git-helper, as that's leftover from ruby to go migration
-
-go-git-helper checkout-default
+git-helper checkout-default

--- a/plugins/git-clean-branches
+++ b/plugins/git-clean-branches
@@ -1,5 +1,3 @@
 #!/bin/sh
 
-# TODO: switch this to plain git-helper, as that's leftover from ruby to go migration
-
-go-git-helper clean-branches
+git-helper clean-branches

--- a/plugins/git-code-request
+++ b/plugins/git-code-request
@@ -1,5 +1,3 @@
 #!/bin/sh
 
-# TODO: switch this to plain git-helper, as that's leftover from ruby to go migration
-
-go-git-helper code-request
+git-helper code-request

--- a/plugins/git-empty-commit
+++ b/plugins/git-empty-commit
@@ -1,5 +1,3 @@
 #!/bin/sh
 
-# TODO: switch this to plain git-helper, as that's leftover from ruby to go migration
-
-go-git-helper empty-commit
+git-helper empty-commit

--- a/plugins/git-forget-local-changes
+++ b/plugins/git-forget-local-changes
@@ -1,5 +1,3 @@
 #!/bin/sh
 
-# TODO: switch this to plain git-helper, as that's leftover from ruby to go migration
-
-go-git-helper forget-local-changes
+git-helper forget-local-changes

--- a/plugins/git-forget-local-commits
+++ b/plugins/git-forget-local-commits
@@ -1,5 +1,3 @@
 #!/bin/sh
 
-# TODO: switch this to plain git-helper, as that's leftover from ruby to go migration
-
-go-git-helper forget-local-commits
+git-helper forget-local-commits

--- a/plugins/git-new-branch
+++ b/plugins/git-new-branch
@@ -1,5 +1,3 @@
 #!/bin/sh
 
-# TODO: switch this to plain git-helper, as that's leftover from ruby to go migration
-
-go-git-helper new-branch $1
+git-helper new-branch $1


### PR DESCRIPTION
## Changes

> A list of the changes that your pull request will make:
>
> * Adding a page "..."
> * Refactoring "..."

* Add a new command which will set the head ref as needed on a local repo
* Print the debug stacktrace when erroring
* Assume all commands are now living at `/usr/local/bin/git-helper` instead of `go-git-helper` (AKA assume the Ruby git-helper is officially uninstalled)

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue URL link
> * Pull Request URL link

## Additional Context

> Add any other context about the problem here.
