### PR TITLE
Show templates even when locally in a nested directory

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -194,6 +194,20 @@ func (g *Git) Fetch() {
 	}
 }
 
+func (g *Git) GetGitRootDir() string {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		if g.Debug {
+			debug.PrintStack()
+		}
+		log.Fatal(err)
+		return ""
+	}
+	return strings.TrimSpace(string(output))
+}
+
 func (g *Git) Pull() {
 	cmd := exec.Command("git", "pull")
 	cmd.Stdout = os.Stdout

--- a/internal/githubPullRequest/githubPullRequest.go
+++ b/internal/githubPullRequest/githubPullRequest.go
@@ -8,6 +8,7 @@ import (
 	"runtime/debug"
 
 	"github.com/emmahsax/go-git-helper/internal/commandline"
+	"github.com/emmahsax/go-git-helper/internal/git"
 	"github.com/emmahsax/go-git-helper/internal/github"
 )
 
@@ -104,13 +105,16 @@ func (pr *GitHubPullRequest) prTemplateOptions() []string {
 		"nonNestedFileName": "pull_request_template",
 	}
 
+	g := git.NewGit(pr.Debug)
+	rootDir := g.GetGitRootDir()
+
 	nestedTemplates, _ := filepath.Glob(
-		filepath.Join(identifiers["templateDir"], identifiers["nestedDirName"], "*.md"),
+		filepath.Join(rootDir, identifiers["templateDir"], identifiers["nestedDirName"], "*.md"),
 	)
 	nonNestedTemplates, _ := filepath.Glob(
-		filepath.Join(identifiers["templateDir"], identifiers["nonNestedFileName"]+".md"),
+		filepath.Join(rootDir, identifiers["templateDir"], identifiers["nonNestedFileName"]+".md"),
 	)
-	rootTemplates, _ := filepath.Glob(filepath.Join(".", identifiers["nonNestedFileName"]+".md"))
+	rootTemplates, _ := filepath.Glob(filepath.Join(rootDir, identifiers["nonNestedFileName"]+".md"))
 
 	allTemplates := append(append(nestedTemplates, nonNestedTemplates...), rootTemplates...)
 	uniqueTemplates := make(map[string]bool)

--- a/internal/githubPullRequest/githubPullRequest_test.go
+++ b/internal/githubPullRequest/githubPullRequest_test.go
@@ -1,7 +1,10 @@
 package githubPullRequest
 
 import (
+	"os"
 	"testing"
+
+	"github.com/emmahsax/go-git-helper/internal/git"
 )
 
 func TestNewPrBody(t *testing.T) {
@@ -12,9 +15,14 @@ func TestNewPrBody(t *testing.T) {
 	options["localRepo"] = "test-repo"
 	pr := NewGitHubPullRequest(options, true)
 	body := pr.newPrBody()
+	g := git.NewGit(pr.Debug)
+	rootDir := g.GetGitRootDir()
+	realTemplate := rootDir + "/.github/pull_request_template.md"
+	content, _ := os.ReadFile(realTemplate)
+	realBody := string(content)
 
-	if body != "" {
-		t.Fatalf(`Body was non-empty: %s`, body)
+	if body != realBody {
+		t.Fatalf(`Body was not the real repo template: %s`, body)
 	}
 }
 
@@ -26,9 +34,12 @@ func TestTemplateNameToApply(t *testing.T) {
 	options["localRepo"] = "test-repo"
 	pr := NewGitHubPullRequest(options, true)
 	template := pr.templateNameToApply()
+	g := git.NewGit(pr.Debug)
+	rootDir := g.GetGitRootDir()
+	realTemplate := rootDir + "/.github/pull_request_template.md"
 
-	if template != "" {
-		t.Fatalf(`Template was non-empty: %s`, template)
+	if template != realTemplate {
+		t.Fatalf(`Template was not the real repo template: %s`, template)
 	}
 }
 
@@ -41,7 +52,7 @@ func TestPrTemplateOptions(t *testing.T) {
 	pr := NewGitHubPullRequest(options, true)
 	tempOptions := pr.prTemplateOptions()
 
-	if len(tempOptions) != 0 {
-		t.Fatalf(`PR options should be 0 when there are no templates: %v`, tempOptions)
+	if len(tempOptions) != 1 {
+		t.Fatalf(`PR options should be 1 when there is a single real repo template: %v`, tempOptions)
 	}
 }

--- a/internal/gitlabMergeRequest/gitlabMergeRequest.go
+++ b/internal/gitlabMergeRequest/gitlabMergeRequest.go
@@ -8,6 +8,7 @@ import (
 	"runtime/debug"
 
 	"github.com/emmahsax/go-git-helper/internal/commandline"
+	"github.com/emmahsax/go-git-helper/internal/git"
 	"github.com/emmahsax/go-git-helper/internal/gitlab"
 )
 
@@ -106,13 +107,16 @@ func (mr *GitLabMergeRequest) mrTemplateOptions() []string {
 		"nonNestedFileName": "merge_request_template",
 	}
 
+	g := git.NewGit(mr.Debug)
+	rootDir := g.GetGitRootDir()
+
 	nestedTemplates, _ := filepath.Glob(
-		filepath.Join(identifiers["templateDir"], identifiers["nestedDirName"], "*.md"),
+		filepath.Join(rootDir, identifiers["templateDir"], identifiers["nestedDirName"], "*.md"),
 	)
 	nonNestedTemplates, _ := filepath.Glob(
-		filepath.Join(identifiers["templateDir"], identifiers["nonNestedFileName"]+".md"),
+		filepath.Join(rootDir, identifiers["templateDir"], identifiers["nonNestedFileName"]+".md"),
 	)
-	rootTemplates, _ := filepath.Glob(filepath.Join(".", identifiers["nonNestedFileName"]+".md"))
+	rootTemplates, _ := filepath.Glob(filepath.Join(rootDir, identifiers["nonNestedFileName"]+".md"))
 
 	allTemplates := append(append(nestedTemplates, nonNestedTemplates...), rootTemplates...)
 	uniqueTemplates := make(map[string]bool)

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	packageVersion = "beta-1.0.2"
+	packageVersion = "beta-1.0.3"
 )
 
 func main() {


### PR DESCRIPTION
## Changes

> A list of the changes that your pull request will make:
>
> * Adding a page "..."
> * Refactoring "..."

Getting the PR/MR templates works well when you're locally in the root git directory (the directory with `.git` in it). However, if you're nested in a sub-directory, this doesn't work well.

So, making the changes so the process will look in your root git directory, no matter where _you_ are on your machine.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue URL link
> * Pull Request URL link

## Additional Context

> Add any other context about the problem here.
