### PR TITLE
Loop through PR creation

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,15 @@
+name: GitLeaks
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  gitleaks:
+    uses: emmahsax/github-actions/.github/workflows/gitleaks.yml@main
+    with:
+      gitleaks_config_paths: "[
+        'go.sum',
+      ]"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,13 +2,10 @@ name: Test
 
 on:
   pull_request:
-  push:
-    branches: [ main ]
   workflow_dispatch:
 
 jobs:
   setup:
-    if: github.event_name == 'pull_request' || !(github.event_name == 'push' && github.ref == 'refs/heads/main')
     outputs:
       branch: ${{ steps.set_branch_variable.outputs.branch }}
     runs-on: ubuntu-latest
@@ -17,15 +14,7 @@ jobs:
         name: Set Branch Variable
         uses: emmahsax/github-actions/set-branch-variable@main
 
-  gitleaks:
-    uses: emmahsax/github-actions/.github/workflows/gitleaks.yml@main
-    with:
-      gitleaks_config_paths: "[
-        'go.sum',
-      ]"
-
   go-test:
-    if: github.event_name == 'pull_request' || !(github.event_name == 'push' && github.ref == 'refs/heads/main')
     needs: [ setup ]
     uses: emmahsax/github-actions/.github/workflows/go-test.yml@main
     with:


### PR DESCRIPTION
## Changes

> A list of the changes that your pull request will make:
>
> * Adding a page "..."
> * Refactoring "..."

Apparently draft PRs are only available on public repositories or private repositories that have payment tiers. So this way, don't fail when draft PRs aren't available, just make it ready for review right away.

Also, break GitLeaks out to its own GHA workflow.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue URL link
> * Pull Request URL link

## Additional Context

> Add any other context about the problem here.
